### PR TITLE
avoid indice type capping to uint32

### DIFF
--- a/vllm/model_executor/layers/fused_moe/layer.py
+++ b/vllm/model_executor/layers/fused_moe/layer.py
@@ -1319,7 +1319,8 @@ class FusedMoE(torch.nn.Module):
                 gating_output=router_logits,
                 topk=top_k,
                 renormalize=renormalize)
-            if indices_type is not None:
+            # uint32 is not a valid index type
+            if indices_type is not None and indices_type != torch.uint32:
                 topk_ids = topk_ids.to(dtype=indices_type)
 
         return topk_weights, topk_ids


### PR DESCRIPTION
## Purpose

Ran into following errors when starting EP on Maverick:
```
(VllmWorker rank=3 pid=1737537) ERROR 06-15 22:58:28 [multiproc_executor.py:527]     run_cutlass_moe_fp8(output, hidden_states, w1, w2, topk_ids,
(VllmWorker rank=3 pid=1737537) ERROR 06-15 22:58:28 [multiproc_executor.py:527]   File "/home/yeq/gitrepos/vllm/vllm/model_executor/layers/fused_moe/cutlass_moe.py", line 89, in run_cutlass_moe_fp8
(VllmWorker rank=3 pid=1737537) ERROR 06-15 22:58:28 [multiproc_executor.py:527]     local_topk_ids = torch.where(expert_map[topk_ids] != -1,
(VllmWorker rank=3 pid=1737537) ERROR 06-15 22:58:28 [multiproc_executor.py:527]                                  ~~~~~~~~~~^^^^^^^^^^
(VllmWorker rank=3 pid=1737537) ERROR 06-15 22:58:28 [multiproc_executor.py:527] IndexError: tensors used as indices must be long, int, byte or bool tensors
```

In the PPLX implementation https://github.com/vllm-project/vllm/pull/18762, the dtype got flipped to uint32. While in `custom_routing_function`, this is already flipped to int32: https://github.com/vllm-project/vllm/blob/a77aea59fd2f0300160dee6fff2e359f572d7f57/vllm/model_executor/models/llama4.py#L57.

Probably we shouldn't Actually not sure this is a good idea.

## Test Plan
```
vllm serve meta-llama/Llama-4-Maverick-17B-128E-Instruct-FP8 \
        --max_model_len 8192 \
        --kv_cache_dtype fp8 \
        --enable-expert-parallel \
        --tensor-parallel-size 8 \
        --trust-remote-code \
        --enforce_eager \
        --gpu-memory-utilization 0.8 \
        --disable-log-requests 2>&1 | tee .env/ep_`date +%Y%m%d_%H%M%S`.log
```
## Test Result

## (Optional) Documentation Update

<!--- pyml disable-next-line no-emphasis-as-heading -->
**BEFORE SUBMITTING, PLEASE READ <https://docs.vllm.ai/en/latest/contributing>** (anything written below this line will be removed by GitHub Actions)
